### PR TITLE
Use nanoTime() instead of currentTimeMillis() when measuring time intervals

### DIFF
--- a/chapter05/cglib-performance/src/main/java/com/apress/prospring5/ch5/ProxyPerfTest.java
+++ b/chapter05/cglib-performance/src/main/java/com/apress/prospring5/ch5/ProxyPerfTest.java
@@ -56,51 +56,51 @@ public class ProxyPerfTest {
         long after = 0;
 
         System.out.println("Testing Advised Method");
-        before = System.currentTimeMillis();
+        before = System.nanoTime();
         for(int x = 0; x < 500000; x++) {
             bean.advised();
         }
-        after = System.currentTimeMillis();
+        after = System.nanoTime();
 
-        System.out.println("Took " + (after - before) + " ms");
+        System.out.println("Took " + (after - before) / 1000000 + " ms");
 
         System.out.println("Testing Unadvised Method");
-        before = System.currentTimeMillis();
+        before = System.nanoTime();
         for(int x = 0; x < 500000; x++) {
             bean.unadvised();
         }
-        after = System.currentTimeMillis();
+        after = System.nanoTime();
 
-        System.out.println("Took " + (after - before) + " ms");
+        System.out.println("Took " + (after - before) / 1000000 + " ms");
 
         System.out.println("Testing equals() Method");
-        before = System.currentTimeMillis();
+        before = System.nanoTime();
         for(int x = 0; x < 500000; x++) {
             bean.equals(bean);
         }
-        after = System.currentTimeMillis();
+        after = System.nanoTime();
 
-        System.out.println("Took " + (after - before) + " ms");
+        System.out.println("Took " + (after - before) / 1000000 + " ms");
 
         System.out.println("Testing hashCode() Method");
-        before = System.currentTimeMillis();
+        before = System.nanoTime();
         for(int x = 0; x < 500000; x++) {
             bean.hashCode();
         }
-        after = System.currentTimeMillis();
+        after = System.nanoTime();
 
-        System.out.println("Took " + (after - before) + " ms");
+        System.out.println("Took " + (after - before) / 1000000 + " ms");
 
         Advised advised = (Advised)bean;
 
         System.out.println("Testing Advised.getProxyTargetClass() Method");
-        before = System.currentTimeMillis();
+        before = System.nanoTime();
         for(int x = 0; x < 500000; x++) {
             advised.getTargetClass();
         }
-        after = System.currentTimeMillis();
+        after = System.nanoTime();
 
-        System.out.println("Took " + (after - before) + " ms");
+        System.out.println("Took " + (after - before) / 1000000 + " ms");
 
         System.out.println(">>>\n");
     }


### PR DESCRIPTION
Using `System.currentTimeMillis()` to measure time intervals is a bad practice.

`currentTimeMillis()` is not fit for measuring time intervals. Although using it in this particular illustrative example might do, I afraid that an unexperienced Java programmer can get a wrong pattern while reading the book. So in my opinion it is better to avoid this practice even in this example.

The reason why one should use `nanoTime()` instead of `currentTimeMillis()` when measuring time intervals is explained in many sources, e. g. in '[Designing Data-Intensive Applications](http://shop.oreilly.com/product/0636920032175.do)' book they say

> Time-of-day clocks are usually synchronized with NTP [...] if the local clock is too far ahead of the NTP server, it may be forcibly reset and appear to jump back to a previous point in time. These jumps, as well as the fact that they often ignore leap seconds, make time-of-day clocks unsuitable for measuring elapsed time. Time-of-day clocks have also historically had quite a coarse-grained resolution [...] A monotonic clock is suitable for measuring a duration (time interval) [...] For example, `clock_gettime(CLOCK_MONOTONIC)` on Linux and `System.nanoTime()` in Java are monotonic clocks. The name comes from the fact that they are guaranteed to always move forwards (whereas a time-of-day clock may jump back in time).

