### PR TITLE
Various small corrections.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ ext {
 	javaElVersion = '3.0.1-b04'
 	glasshfishELVersion = '2.2.1-b05'
 	jmsVersion = '2.0'
-	artemisVersion = '2.1.0'
+	artemisVersion = '2.4.0'
 	hornetqVersion = '2.4.0.Final'
 	castorVersion = '1.4.1'
 	jacksonVersion = '2.9.0'
@@ -134,7 +134,7 @@ ext {
 			guava          : "com.google.guava:guava:$guavaVersion",
 			joda           : "joda-time:joda-time:$jodaVersion",
 			usertype       : "org.jadira.usertype:usertype.core:$utVersion",
-			artemis        : "org.apache.activemq:artemis-jms-server:2.1.0",
+			artemis        : "org.apache.activemq:artemis-jms-server:$artemisVersion",
 			javaEl         : "javax.el:javax.el-api:$javaElVersion",
 			glassfishEl    : "org.glassfish.web:el-impl:$glasshfishELVersion",
 			jms            : "javax.jms:javax.jms-api:$jmsVersion",
@@ -157,7 +157,7 @@ ext {
 			tomcatWsEmbed: "org.apache.tomcat.embed:tomcat-embed-websocket:$twsVersion",
 			httpclient   : "org.apache.httpcomponents:httpclient:$httpclientVersion",
 			websocket    : "javax.websocket:javax.websocket-api:1.1",
-			servlet      : "javax.servlet:javax.servlet-api:3.1.0",
+			servlet      : "javax:javaee-web-api:7.0",
 	]
 
 	react = [

--- a/chapter03/bean-inheritance/build.gradle
+++ b/chapter03/bean-inheritance/build.gradle
@@ -3,7 +3,7 @@ jar {
 		attributes(
 				"Created-By": "Iuliana Cosmina",
 				"Specification-Title": "Pro Spring 5",
-				"Main-Class": "com.apress.prospring5.ch3.xml.SimpleBean",
+				"Main-Class": "com.apress.prospring5.ch3.xml.InheritanceDemo",
 				"Class-Path": configurations.compile.collect { it.getName() }.join(' ')
 		)
 	}

--- a/chapter03/bean-instantiation-mode/build.gradle
+++ b/chapter03/bean-instantiation-mode/build.gradle
@@ -3,7 +3,7 @@ jar {
 		attributes(
 				"Created-By": "Iuliana Cosmina",
 				"Specification-Title": "Pro Spring 5",
-				"Main-Class": "com.apress.prospring5.ch3.NonSingleton",
+				"Main-Class": "com.apress.prospring5.ch3.NonSingletonDemo",
 				"Class-Path": configurations.compile.collect { it.getName() }.join(' ')
 		)
 	}

--- a/chapter03/collections/build.gradle
+++ b/chapter03/collections/build.gradle
@@ -2,7 +2,7 @@ jar {
 	manifest {
 		attributes("Created-By"         : "Iuliana Cosmina",
 				"Specification-Title": "Pro Spring 5",
-				"Main-Class"         : "com.apress.prospring5.ch3.annotation.CollectionInjection",
+				"Main-Class"         : "com.apress.prospring5.ch3.annotated.CollectionInjection",
 				"Class-Path"         : configurations.compile.collect { it.getName() }.join(' '))
 	}
 }

--- a/chapter03/constructor-injection/build.gradle
+++ b/chapter03/constructor-injection/build.gradle
@@ -8,7 +8,7 @@ jar {
 	manifest {
 		attributes("Created-By"         : "Iuliana Cosmina",
 				"Specification-Title": "Pro Spring 5",
-				"Main-Class"         : "com.apress.prospring5.ch3.annotation.ConstructorConfusion",
+				"Main-Class"         : "com.apress.prospring5.ch3.annotated.ConstructorConfusion",
 				"Class-Path"         : configurations.compile.collect { it.getName() }.join(' '))
 	}
 }

--- a/chapter03/field-injection/build.gradle
+++ b/chapter03/field-injection/build.gradle
@@ -2,7 +2,7 @@ jar {
     manifest {
         attributes("Created-By"      : "Iuliana Cosmina",
                 "Specification-Title": "Pro Spring 5",
-                "Main-Class"         : "com.apress.prospring5.ch3.annotation.FieldInjection",
+                "Main-Class"         : "com.apress.prospring5.ch3.annotated.FieldInjection",
                 "Class-Path"         : configurations.compile.collect { it.getName() }.join(' '))
     }
 }

--- a/chapter03/method-replacement/src/main/java/com/apress/prospring5/ch3/FormatMessageReplacer.java
+++ b/chapter03/method-replacement/src/main/java/com/apress/prospring5/ch3/FormatMessageReplacer.java
@@ -7,7 +7,7 @@ import java.lang.reflect.Method;
 public class FormatMessageReplacer implements MethodReplacer {
 
 	@Override
-	public Object reimplement(Object arg0, Method method, Object... args)
+	public Object reimplement(Object arg0, Method method, Object[] args)
 			throws Throwable {
 		if (isFormatMessageMethod(method)) {
 			String msg = (String) args[0];

--- a/chapter03/simple-types/build.gradle
+++ b/chapter03/simple-types/build.gradle
@@ -2,7 +2,7 @@ jar {
 	manifest {
 		attributes("Created-By"      : "Iuliana Cosmina",
 				"Specification-Title": "Pro Spring 5",
-				"Main-Class"         : "com.apress.prospring5.ch3.annotation.InjectSimpleSpel",
+				"Main-Class"         : "com.apress.prospring5.ch3.annotated.InjectSimpleSpel",
 				"Class-Path"         : configurations.compile.collect { it.getName() }.join(' '))
 	}
 }

--- a/chapter04/bean-init-method/build.gradle
+++ b/chapter04/bean-init-method/build.gradle
@@ -3,7 +3,7 @@ jar {
 		attributes(
 				"Created-By": "Iuliana Cosmina",
 				"Specification-Title": "Pro Spring 5",
-				"Main-Class": "com.apress.prospring5.ch4.SimpleBean",
+				"Main-Class": "com.apress.prospring5.ch4.Singer",
 				"Class-Path": configurations.compile.collect { it.getName() }.join(' ')
 		)
 	}

--- a/chapter04/bean-name-aware/build.gradle
+++ b/chapter04/bean-name-aware/build.gradle
@@ -2,7 +2,7 @@ jar {
 	manifest {
 		attributes( "Created-By"         : "Iuliana Cosmina",
 		             "Specification-Title": "Pro Spring 5",
-		             "Main-Class"         : "com.apress.prospring5.ch4.BeanNamePrinterDemo",
+		             "Main-Class"         : "com.apress.prospring5.ch4.NamedSingerDemo",
 		             "Class-Path"         : configurations.compile.collect { it.getName() }.join(' '))
 	}
 }

--- a/chapter04/initializing-bean/build.gradle
+++ b/chapter04/initializing-bean/build.gradle
@@ -2,7 +2,7 @@ jar {
 	manifest {
 		attributes("Created-By"      : "Iuliana Cosmina",
 				"Specification-Title": "Pro Spring 5",
-				"Main-Class"         : "com.apress.prospring5.ch4.SimpleBeanWithInterface",
+				"Main-Class"         : "com.apress.prospring5.ch4.SingerWithInterface",
 				"Class-Path"         : configurations.compile.collect { it.getName() }.join(' '))
 	}
 }

--- a/chapter04/java-config-message-provider/build.gradle
+++ b/chapter04/java-config-message-provider/build.gradle
@@ -7,7 +7,7 @@ jar {
 	manifest {
 		attributes("Created-By"      : "Iuliana Cosmina",
 				"Specification-Title": "Pro Spring 5",
-				"Main-Class"         : "com.apress.prospring5.ch4.JavaConfigSimpleDemo",
+				"Main-Class"         : "com.apress.prospring5.ch4.JavaConfigExampleOne",
 				"Class-Path"         : configurations.compile.collect { it.getName() }.join(' '))
 	}
 }

--- a/chapter04/post-construct/build.gradle
+++ b/chapter04/post-construct/build.gradle
@@ -2,7 +2,7 @@ jar {
 	manifest {
 		attributes("Created-By"      : "Iuliana Cosmina",
 				"Specification-Title": "Pro Spring 5",
-				"Main-Class"         : "com.apress.prospring5.ch4.SimpleBeanWithJSR250",
+				"Main-Class"         : "com.apress.prospring5.ch4.SingerWithJSR250",
 				"Class-Path"         : configurations.compile.collect { it.getName() }.join(' '))
 	}
 }

--- a/chapter04/property-placeholder/build.gradle
+++ b/chapter04/property-placeholder/build.gradle
@@ -2,7 +2,7 @@ jar {
 	manifest {
 		attributes("Created-By"      : "Iuliana Cosmina",
 				"Specification-Title": "Pro Spring 5",
-				"Main-Class"         : "com.apress.prospring5.ch4.PlaceHolderSample",
+				"Main-Class"         : "com.apress.prospring5.ch4.PlaceHolderDemo",
 				"Class-Path"         : configurations.compile.collect { it.getName() }.join(' '))
 	}
 }

--- a/chapter04/shutdown-hook/build.gradle
+++ b/chapter04/shutdown-hook/build.gradle
@@ -2,7 +2,7 @@ jar {
 	manifest {
 		attributes("Created-By"      : "Iuliana Cosmina",
 				"Specification-Title": "Pro Spring 5",
-				"Main-Class"         : "com.apress.prospring5.ch4.DestructiveBeanWithInterface",
+				"Main-Class"         : "com.apress.prospring5.ch4.DestructiveBeanWithHook",
 				"Class-Path"         : configurations.compile.collect { it.getName() }.join(' '))
 	}
 }

--- a/chapter05/aop-hello-world/build.gradle
+++ b/chapter05/aop-hello-world/build.gradle
@@ -3,7 +3,7 @@ jar {
 		attributes(
 				"Created-By": "Iuliana Cosmina",
 				"Specification-Title": "Pro Spring 5",
-				"Main-Class": "com.apress.prospring5.ch5.HelloWorldAOPDemo",
+				"Main-Class": "com.apress.prospring5.ch5.AgentAOPDemo",
 				"Class-Path": configurations.compile.collect { it.getName() }.join(' ')
 		)
 	}

--- a/chapter05/aspectj-annotations/build.gradle
+++ b/chapter05/aspectj-annotations/build.gradle
@@ -9,7 +9,6 @@ jar {
 		attributes(
 				"Created-By": "Iuliana Cosmina",
 				"Specification-Title": "Pro Spring 5",
-				"Main-Class": "com.apress.prospring5.ch5.AspectJAnnotationDemo",
 				"Class-Path": configurations.compile.collect { it.getName() }.join(' ')
 		)
 	}

--- a/chapter05/dynamic-pointcut/src/main/java/com/apress/prospring5/ch5/SimpleDynamicPointcut.java
+++ b/chapter05/dynamic-pointcut/src/main/java/com/apress/prospring5/ch5/SimpleDynamicPointcut.java
@@ -13,7 +13,7 @@ public class SimpleDynamicPointcut extends DynamicMethodMatcherPointcut {
     }
 
     @Override
-    public boolean matches(Method method, Class<?> cls, Object[] args) {
+    public boolean matches(Method method, Class<?> cls, Object... args) {
         System.out.println("Dynamic check for " + method.getName());
 
         int x = ((Integer) args[0]).intValue();

--- a/chapter06/plain-jdbc/src/main/java/com/apress/prospring5/ch6/entities/Singer.java
+++ b/chapter06/plain-jdbc/src/main/java/com/apress/prospring5/ch6/entities/Singer.java
@@ -37,7 +37,7 @@ public class Singer implements Serializable {
 		return this.lastName;
 	}
 
-	public boolean addAbum(Album album) {
+	public boolean addAlbum(Album album) {
 		if (albums == null) {
 			albums = new ArrayList<>();
 			albums.add(album);

--- a/chapter06/spring-jdbc-annotations/src/main/java/com/apress/prospring5/ch6/dao/JdbcSingerDao.java
+++ b/chapter06/spring-jdbc-annotations/src/main/java/com/apress/prospring5/ch6/dao/JdbcSingerDao.java
@@ -158,7 +158,7 @@ public class JdbcSingerDao implements SingerDao {
 	@Override public void delete(Long singerId) {
 		Map<String, Object> paramMap = new HashMap<>();
 		paramMap.put("id", singerId);
-		updateSinger.updateByNamedParam(paramMap);
+		deleteSinger.updateByNamedParam(paramMap);
 		logger.info("Deleting singer with id: " + singerId);
 	}
 }

--- a/chapter06/spring-jdbc-annotations/src/test/java/com/apress/prospring5/ch6/AnnotationJdbcTest.java
+++ b/chapter06/spring-jdbc-annotations/src/test/java/com/apress/prospring5/ch6/AnnotationJdbcTest.java
@@ -90,13 +90,13 @@ public class AnnotationJdbcTest {
 		album.setTitle("My Kind of Blues");
 		album.setReleaseDate(new Date(
 				(new GregorianCalendar(1961, 7, 18)).getTime().getTime()));
-		singer.addAbum(album);
+		singer.addAlbum(album);
 
 		album = new Album();
 		album.setTitle("A Heart Full of Blues");
 		album.setReleaseDate(new Date(
 				(new GregorianCalendar(1962, 3, 20)).getTime().getTime()));
-		singer.addAbum(album);
+		singer.addAlbum(album);
 
 		singerDao.insertWithAlbum(singer);
 

--- a/chapter06/spring-jdbc-resultsetextractor/src/main/java/com/apress/prospring5/ch6/JdbcSingerDao.java
+++ b/chapter06/spring-jdbc-resultsetextractor/src/main/java/com/apress/prospring5/ch6/JdbcSingerDao.java
@@ -48,7 +48,7 @@ public class JdbcSingerDao implements SingerDao, InitializingBean {
 					album.setSingerId(id);
 					album.setTitle(rs.getString("title"));
 					album.setReleaseDate(rs.getDate("release_date"));
-					singer.addAbum(album);
+					singer.addAlbum(album);
 				}
 			}
 			return new ArrayList<>(map.values());

--- a/chapter07/hibernate-base/src/main/java/com/apress/prospring5/ch7/entities/Singer.java
+++ b/chapter07/hibernate-base/src/main/java/com/apress/prospring5/ch7/entities/Singer.java
@@ -90,7 +90,7 @@ public class Singer implements Serializable {
 		this.lastName = lastName;
 	}
 
-	public boolean addAbum(Album album) {
+	public boolean addAlbum(Album album) {
 		album.setSinger(this);
 		return getAlbums().add(album);
 	}

--- a/chapter07/hibernate-base/src/test/java/com/apress/prospring5/ch7/SingerDaoTest.java
+++ b/chapter07/hibernate-base/src/test/java/com/apress/prospring5/ch7/SingerDaoTest.java
@@ -69,13 +69,13 @@ public class SingerDaoTest {
 		album.setTitle("My Kind of Blues");
 		album.setReleaseDate(new java.sql.Date(
 				(new GregorianCalendar(1961, 7, 18)).getTime().getTime()));
-		singer.addAbum(album);
+		singer.addAlbum(album);
 
 		album = new Album();
 		album.setTitle("A Heart Full of Blues");
 		album.setReleaseDate(new java.sql.Date(
 				(new GregorianCalendar(1962, 3, 20)).getTime().getTime()));
-		singer.addAbum(album);
+		singer.addAlbum(album);
 
 		singerDao.save(singer);
 		assertNotNull(singer.getId());

--- a/chapter07/hibernate-crud/src/main/java/com/apress/prospring5/ch7/config/DBInitializer.java
+++ b/chapter07/hibernate-crud/src/main/java/com/apress/prospring5/ch7/config/DBInitializer.java
@@ -52,13 +52,13 @@ public class DBInitializer {
 		album1.setTitle("The Search For Everything");
 		album1.setReleaseDate(new java.sql.Date(
 				(new GregorianCalendar(2017, 0, 20)).getTime().getTime()));
-		singer.addAbum(album1);
+		singer.addAlbum(album1);
 
 		Album album2 = new Album();
 		album2.setTitle("Battle Studies");
 		album2.setReleaseDate(new java.sql.Date(
 				(new GregorianCalendar(2009, 10, 17)).getTime().getTime()));
-		singer.addAbum(album2);
+		singer.addAlbum(album2);
 
 		singerDao.save(singer);
 
@@ -73,7 +73,7 @@ public class DBInitializer {
 		album.setTitle("From The Cradle");
 		album.setReleaseDate(new java.sql.Date(
 				(new GregorianCalendar(1994, 8, 13)).getTime().getTime()));
-		singer.addAbum(album);
+		singer.addAlbum(album);
 
 		singerDao.save(singer);
 

--- a/chapter07/hibernate-crud/src/main/java/com/apress/prospring5/ch7/dao/InstrumentDaoImpl.java
+++ b/chapter07/hibernate-crud/src/main/java/com/apress/prospring5/ch7/dao/InstrumentDaoImpl.java
@@ -16,7 +16,7 @@ import javax.annotation.Resource;
 @Repository("instrumentDao")
 public class InstrumentDaoImpl implements InstrumentDao {
 
-	private static final Log logger = LogFactory.getLog(SingerDaoImpl.class);
+	private static final Log logger = LogFactory.getLog(InstrumentDaoImpl.class);
 	private SessionFactory sessionFactory;
 
 

--- a/chapter07/hibernate-crud/src/main/java/com/apress/prospring5/ch7/entities/Singer.java
+++ b/chapter07/hibernate-crud/src/main/java/com/apress/prospring5/ch7/entities/Singer.java
@@ -79,7 +79,7 @@ public class Singer extends AbstractEntity {
 		this.lastName = lastName;
 	}
 
-	public boolean addAbum(Album album) {
+	public boolean addAlbum(Album album) {
 		album.setSinger(this);
 		return albums.add(album);
 	}

--- a/chapter07/hibernate-crud/src/test/java/com/apress/prospring5/ch7/SingerDaoTest.java
+++ b/chapter07/hibernate-crud/src/test/java/com/apress/prospring5/ch7/SingerDaoTest.java
@@ -69,13 +69,13 @@ public class SingerDaoTest {
 		album.setTitle("My Kind of Blues");
 		album.setReleaseDate(new java.sql.Date(
 				(new GregorianCalendar(1961, 7, 18)).getTime().getTime()));
-		singer.addAbum(album);
+		singer.addAlbum(album);
 
 		album = new Album();
 		album.setTitle("A Heart Full of Blues");
 		album.setReleaseDate(new java.sql.Date(
 				(new GregorianCalendar(1962, 3, 20)).getTime().getTime()));
-		singer.addAbum(album);
+		singer.addAlbum(album);
 
 		singerDao.save(singer);
 		assertNotNull(singer.getId());

--- a/chapter08/boot-jpa/src/main/java/com/apress/prospring5/ch8/config/DBInitializer.java
+++ b/chapter08/boot-jpa/src/main/java/com/apress/prospring5/ch8/config/DBInitializer.java
@@ -55,13 +55,13 @@ public class DBInitializer {
 		album1.setTitle("The Search For Everything");
 		album1.setReleaseDate(new java.sql.Date(
 				(new GregorianCalendar(2017, 0, 20)).getTime().getTime()));
-		singer.addAbum(album1);
+		singer.addAlbum(album1);
 
 		Album album2 = new Album();
 		album2.setTitle("Battle Studies");
 		album2.setReleaseDate(new java.sql.Date(
 				(new GregorianCalendar(2009, 10, 17)).getTime().getTime()));
-		singer.addAbum(album2);
+		singer.addAlbum(album2);
 
 		singerRepository.save(singer);
 
@@ -76,7 +76,7 @@ public class DBInitializer {
 		album.setTitle("From The Cradle");
 		album.setReleaseDate(new java.sql.Date(
 				(new GregorianCalendar(1994, 8, 13)).getTime().getTime()));
-		singer.addAbum(album);
+		singer.addAlbum(album);
 
 		singerRepository.save(singer);
 

--- a/chapter08/boot-jpa/src/main/java/com/apress/prospring5/ch8/entities/Singer.java
+++ b/chapter08/boot-jpa/src/main/java/com/apress/prospring5/ch8/entities/Singer.java
@@ -125,7 +125,7 @@ public class Singer implements Serializable {
      this.albums = albums;
     }
 
-    public boolean addAbum(Album album) {
+    public boolean addAlbum(Album album) {
         album.setSinger(this);
         return getAlbums().add(album);
     }

--- a/chapter08/hibernate-envers/src/main/java/com/apress/prospring5/ch8/SpringEnversJPADemo.java
+++ b/chapter08/hibernate-envers/src/main/java/com/apress/prospring5/ch8/SpringEnversJPADemo.java
@@ -38,11 +38,11 @@ public class SpringEnversJPADemo {
 
         SingerAudit oldSinger = singerAuditService.findAuditByRevision(4l, 1);
         System.out.println("");
-        System.out.println("Old Singer with id 1 and rev 1:" + oldSinger);
+        System.out.println("Old Singer with id 4 and rev 1:" + oldSinger);
         System.out.println("");
         oldSinger = singerAuditService.findAuditByRevision(4l, 2);
         System.out.println("");
-        System.out.println("Old Singer with id 1 and rev 2:" + oldSinger);
+        System.out.println("Old Singer with id 4 and rev 2:" + oldSinger);
         System.out.println("");
 
         ctx.close();

--- a/chapter08/hibernate-envers/src/main/java/com/apress/prospring5/ch8/config/EnversConfig.java
+++ b/chapter08/hibernate-envers/src/main/java/com/apress/prospring5/ch8/config/EnversConfig.java
@@ -84,7 +84,6 @@ public class EnversConfig {
 		LocalContainerEntityManagerFactoryBean factoryBean = new LocalContainerEntityManagerFactoryBean();
 		factoryBean.setPackagesToScan("com.apress.prospring5.ch8.entities");
 		factoryBean.setDataSource(dataSource());
-		factoryBean.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
 		factoryBean.setJpaProperties(hibernateProperties());
 		factoryBean.setJpaVendorAdapter(jpaVendorAdapter());
 		factoryBean.afterPropertiesSet();

--- a/chapter08/jpa-criteria/src/main/java/com/apress/prospring5/ch8/Singer.java
+++ b/chapter08/jpa-criteria/src/main/java/com/apress/prospring5/ch8/Singer.java
@@ -109,7 +109,7 @@ public class Singer implements Serializable {
      this.albums = albums;
     }
 
-    public boolean addAbum(Album album) {
+    public boolean addAlbum(Album album) {
         album.setSinger(this);
         return getAlbums().add(album);
     }

--- a/chapter08/jpa-criteria/src/main/java/com/apress/prospring5/ch8/config/JpaConfig.java
+++ b/chapter08/jpa-criteria/src/main/java/com/apress/prospring5/ch8/config/JpaConfig.java
@@ -68,7 +68,6 @@ public class JpaConfig {
 		LocalContainerEntityManagerFactoryBean factoryBean = new LocalContainerEntityManagerFactoryBean();
 		factoryBean.setPackagesToScan("com.apress.prospring5.ch8");
 		factoryBean.setDataSource(dataSource());
-		factoryBean.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
 		factoryBean.setJpaProperties(hibernateProperties());
 		factoryBean.setJpaVendorAdapter(jpaVendorAdapter());
 		factoryBean.afterPropertiesSet();

--- a/chapter08/jpa-criteria/src/test/java/com/apress/prospring5/ch8/SingerJPATest.java
+++ b/chapter08/jpa-criteria/src/test/java/com/apress/prospring5/ch8/SingerJPATest.java
@@ -31,7 +31,7 @@ public class SingerJPATest {
 	}
 
 	@Test
-	public void tesFindByCriteriaQuery() {
+	public void testFindByCriteriaQuery() {
 		List<Singer> singers = singerService.findByCriteriaQuery("John", "Mayer");
 		assertEquals(1, singers.size());
 		listSingersWithAlbum(singers);

--- a/chapter08/jpa-crud/build.gradle
+++ b/chapter08/jpa-crud/build.gradle
@@ -2,7 +2,7 @@ jar {
 	manifest {
 		attributes("Created-By"      : "Iuliana Cosmina",
 				"Specification-Title": "Pro Spring 5",
-				"Main-Class"         : "com.apress.prospring5.ch6.SpringJPADemo",
+				"Main-Class"         : "com.apress.prospring5.ch8.SpringJPADemo",
 				"Class-Path"         : configurations.compile.collect { it.getName() }.join(' '))
 	}
 }

--- a/chapter08/jpa-crud/src/main/java/com/apress/prospring5/ch8/config/JpaConfig.java
+++ b/chapter08/jpa-crud/src/main/java/com/apress/prospring5/ch8/config/JpaConfig.java
@@ -68,7 +68,6 @@ public class JpaConfig {
 		LocalContainerEntityManagerFactoryBean factoryBean = new LocalContainerEntityManagerFactoryBean();
 		factoryBean.setPackagesToScan("com.apress.prospring5.ch8.entities");
 		factoryBean.setDataSource(dataSource());
-		factoryBean.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
 		factoryBean.setJpaProperties(hibernateProperties());
 		factoryBean.setJpaVendorAdapter(jpaVendorAdapter());
 		factoryBean.afterPropertiesSet();

--- a/chapter08/jpa-crud/src/main/java/com/apress/prospring5/ch8/entities/Singer.java
+++ b/chapter08/jpa-crud/src/main/java/com/apress/prospring5/ch8/entities/Singer.java
@@ -125,7 +125,7 @@ public class Singer implements Serializable {
      this.albums = albums;
     }
 
-    public boolean addAbum(Album album) {
+    public boolean addAlbum(Album album) {
         album.setSinger(this);
         return getAlbums().add(album);
     }

--- a/chapter08/jpa-crud/src/test/java/com/apress/prospring5/ch8/SingerJPATest.java
+++ b/chapter08/jpa-crud/src/test/java/com/apress/prospring5/ch8/SingerJPATest.java
@@ -80,13 +80,13 @@ public class SingerJPATest {
 		album.setTitle("My Kind of Blues");
 		album.setReleaseDate(new java.sql.Date(
 				(new GregorianCalendar(1961, 7, 18)).getTime().getTime()));
-		singer.addAbum(album);
+		singer.addAlbum(album);
 
 		album = new Album();
 		album.setTitle("A Heart Full of Blues");
 		album.setReleaseDate(new java.sql.Date(
 				(new GregorianCalendar(1962, 3, 20)).getTime().getTime()));
-		singer.addAbum(album);
+		singer.addAlbum(album);
 
 		singerService.save(singer);
 		assertNotNull(singer.getId());

--- a/chapter08/spring-data-jpa-alt/build.gradle
+++ b/chapter08/spring-data-jpa-alt/build.gradle
@@ -1,4 +1,4 @@
-// this ia an alternative example for the Spring Data JPA example using JpaRepository
+// this is an alternative example for the Spring Data JPA example using JpaRepository
 dependencies {
 	compile spring.data, misc.guava
 }

--- a/chapter08/spring-data-jpa-alt/src/main/java/com/apress/prospring5/ch8/config/DBInitializer.java
+++ b/chapter08/spring-data-jpa-alt/src/main/java/com/apress/prospring5/ch8/config/DBInitializer.java
@@ -52,13 +52,13 @@ public class DBInitializer {
 		album1.setTitle("The Search For Everything");
 		album1.setReleaseDate(new java.sql.Date(
 				(new GregorianCalendar(2017, 0, 20)).getTime().getTime()));
-		singer.addAbum(album1);
+		singer.addAlbum(album1);
 
 		Album album2 = new Album();
 		album2.setTitle("Battle Studies");
 		album2.setReleaseDate(new java.sql.Date(
 				(new GregorianCalendar(2009, 10, 17)).getTime().getTime()));
-		singer.addAbum(album2);
+		singer.addAlbum(album2);
 
 		singerRepository.save(singer);
 
@@ -73,7 +73,7 @@ public class DBInitializer {
 		album.setTitle("From The Cradle");
 		album.setReleaseDate(new java.sql.Date(
 				(new GregorianCalendar(1994, 8, 13)).getTime().getTime()));
-		singer.addAbum(album);
+		singer.addAlbum(album);
 
 		singerRepository.save(singer);
 

--- a/chapter08/spring-data-jpa-alt/src/main/java/com/apress/prospring5/ch8/config/DataJpaConfig.java
+++ b/chapter08/spring-data-jpa-alt/src/main/java/com/apress/prospring5/ch8/config/DataJpaConfig.java
@@ -70,7 +70,6 @@ public class DataJpaConfig {
 		LocalContainerEntityManagerFactoryBean factoryBean = new LocalContainerEntityManagerFactoryBean();
 		factoryBean.setPackagesToScan("com.apress.prospring5.ch8.entities");
 		factoryBean.setDataSource(dataSource());
-		factoryBean.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
 		factoryBean.setJpaProperties(hibernateProperties());
 		factoryBean.setJpaVendorAdapter(jpaVendorAdapter());
 		factoryBean.afterPropertiesSet();

--- a/chapter08/spring-data-jpa-alt/src/main/java/com/apress/prospring5/ch8/entities/Singer.java
+++ b/chapter08/spring-data-jpa-alt/src/main/java/com/apress/prospring5/ch8/entities/Singer.java
@@ -109,7 +109,7 @@ public class Singer implements Serializable {
      this.albums = albums;
     }
 
-    public boolean addAbum(Album album) {
+    public boolean addAlbum(Album album) {
         album.setSinger(this);
         return getAlbums().add(album);
     }

--- a/chapter08/spring-data-jpa-audit/src/main/java/com/apress/prospring5/ch8/SpringAuditJPADemo.java
+++ b/chapter08/spring-data-jpa-audit/src/main/java/com/apress/prospring5/ch8/SpringAuditJPADemo.java
@@ -38,7 +38,7 @@ public class SpringAuditJPADemo {
 
         singer = singerAuditService.findById(4l);
         System.out.println("");
-        System.out.println("Singer with id 1:" + singer);
+        System.out.println("Singer with id 4:" + singer);
         System.out.println("");
 
         System.out.println("Update singer");

--- a/chapter08/spring-data-jpa-audit/src/main/java/com/apress/prospring5/ch8/config/AuditConfig.java
+++ b/chapter08/spring-data-jpa-audit/src/main/java/com/apress/prospring5/ch8/config/AuditConfig.java
@@ -72,7 +72,6 @@ public class AuditConfig {
 		LocalContainerEntityManagerFactoryBean factoryBean = new LocalContainerEntityManagerFactoryBean();
 		factoryBean.setPackagesToScan("com.apress.prospring5.ch8.entities");
 		factoryBean.setDataSource(dataSource());
-		factoryBean.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
 		factoryBean.setJpaProperties(hibernateProperties());
 		factoryBean.setJpaVendorAdapter(jpaVendorAdapter());
 		factoryBean.afterPropertiesSet();

--- a/chapter08/spring-data-jpa/src/main/java/com/apress/prospring5/ch8/config/DataJpaConfig.java
+++ b/chapter08/spring-data-jpa/src/main/java/com/apress/prospring5/ch8/config/DataJpaConfig.java
@@ -70,7 +70,6 @@ public class DataJpaConfig {
 		LocalContainerEntityManagerFactoryBean factoryBean = new LocalContainerEntityManagerFactoryBean();
 		factoryBean.setPackagesToScan("com.apress.prospring5.ch8.entities");
 		factoryBean.setDataSource(dataSource());
-		factoryBean.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
 		factoryBean.setJpaProperties(hibernateProperties());
 		factoryBean.setJpaVendorAdapter(jpaVendorAdapter());
 		factoryBean.afterPropertiesSet();

--- a/chapter08/spring-data-jpa/src/main/java/com/apress/prospring5/ch8/entities/Singer.java
+++ b/chapter08/spring-data-jpa/src/main/java/com/apress/prospring5/ch8/entities/Singer.java
@@ -109,7 +109,7 @@ public class Singer implements Serializable {
      this.albums = albums;
     }
 
-    public boolean addAbum(Album album) {
+    public boolean addAlbum(Album album) {
         album.setSinger(this);
         return getAlbums().add(album);
     }

--- a/chapter09/base-dao/src/main/java/com/apress/prospring5/ch9/config/DBInitializer.java
+++ b/chapter09/base-dao/src/main/java/com/apress/prospring5/ch9/config/DBInitializer.java
@@ -35,13 +35,13 @@ public class DBInitializer {
 		album1.setTitle("The Search For Everything");
 		album1.setReleaseDate(new java.sql.Date(
 				(new GregorianCalendar(2017, 0, 20)).getTime().getTime()));
-		singer.addAbum(album1);
+		singer.addAlbum(album1);
 
 		Album album2 = new Album();
 		album2.setTitle("Battle Studies");
 		album2.setReleaseDate(new java.sql.Date(
 				(new GregorianCalendar(2009, 10, 17)).getTime().getTime()));
-		singer.addAbum(album2);
+		singer.addAlbum(album2);
 
 		singerRepository.save(singer);
 
@@ -55,7 +55,7 @@ public class DBInitializer {
 		album.setTitle("From The Cradle");
 		album.setReleaseDate(new java.sql.Date(
 				(new GregorianCalendar(1994, 8, 13)).getTime().getTime()));
-		singer.addAbum(album);
+		singer.addAlbum(album);
 
 		singerRepository.save(singer);
 

--- a/chapter09/base-dao/src/main/java/com/apress/prospring5/ch9/config/XAJpaConfig.java
+++ b/chapter09/base-dao/src/main/java/com/apress/prospring5/ch9/config/XAJpaConfig.java
@@ -48,8 +48,8 @@ public class XAJpaConfig {
 	public Properties xaAProperties() {
 		Properties xaProp = new Properties();
 		xaProp.put("databaseName", "musicdb_a");
-		xaProp.put("user", "prospring5_a");
-		xaProp.put("password", "prospring5_a");
+		xaProp.put("user", "prospring5_A");
+		xaProp.put("password", "prospring5_A");
 		return xaProp;
 	}
 
@@ -73,8 +73,8 @@ public class XAJpaConfig {
 	public Properties xaBProperties() {
 		Properties xaProp = new Properties();
 		xaProp.put("databaseName", "musicdb_b");
-		xaProp.put("user", "prospring5_b");
-		xaProp.put("password", "prospring5_b");
+		xaProp.put("user", "prospring5_B");
+		xaProp.put("password", "prospring5_B");
 		return xaProp;
 	}
 

--- a/chapter09/base-dao/src/main/java/com/apress/prospring5/ch9/entities/Singer.java
+++ b/chapter09/base-dao/src/main/java/com/apress/prospring5/ch9/entities/Singer.java
@@ -90,7 +90,7 @@ public class Singer implements Serializable {
      this.albums = albums;
     }
 
-    public boolean addAbum(Album album) {
+    public boolean addAlbum(Album album) {
         album.setSinger(this);
         return getAlbums().add(album);
     }

--- a/chapter09/base-dao/src/main/resources/logback.xml
+++ b/chapter09/base-dao/src/main/resources/logback.xml
@@ -11,7 +11,7 @@
         </encoder>
     </appender>
 
-    <logger name="com.apress.prospring5.ch8" level="debug"/>
+    <logger name="com.apress.prospring5.ch9" level="debug"/>
 
     <logger name="org.springframework" level="off"/>
 

--- a/chapter09/transactions-annotation/src/main/resources/spring/tx-annotation-app-context.xml
+++ b/chapter09/transactions-annotation/src/main/resources/spring/tx-annotation-app-context.xml
@@ -17,7 +17,7 @@
         http://www.springframework.org/schema/context/spring-context.xsd">
 
     <!-- this is a sample configuration file, depicted here for legacy purposes, to show you how it was done before.
-    It is not really used anywhere in this example, but provided the necessary dependecnies this configuration is functional. -->
+    It is not really used anywhere in this example, but provided the necessary dependencies this configuration is functional. -->
     <jdbc:embedded-database id="dataSource" type="H2">
         <jdbc:script location="classpath:db/schema.sql"/>
         <jdbc:script location="classpath:db/test-data.sql"/>

--- a/chapter09/transactions-jta/src/main/java/com/apress/prospring5/ch9/TxJtaDemo.java
+++ b/chapter09/transactions-jta/src/main/java/com/apress/prospring5/ch9/TxJtaDemo.java
@@ -37,7 +37,7 @@ public class TxJtaDemo {
 		if (singers.size()!= 2) {
 			logger.error("--> Something went wrong.");
 		} else {
-			logger.info("--> Singers form both DBs: " + singers);
+			logger.info("--> Singers from both DBs: " + singers);
 		}
 		ctx.close();
 	}

--- a/chapter09/transactions-programmatic/src/main/resources/spring/tx-programmatic-app-context.xml
+++ b/chapter09/transactions-programmatic/src/main/resources/spring/tx-programmatic-app-context.xml
@@ -14,7 +14,7 @@
         http://www.springframework.org/schema/context/spring-context.xsd">
 
     <!-- this is a sample configuration file, depicted here for legacy purposes, to show you how it was done before.
-   It is not really used anywhere in this example, but provided the necessary dependecnies this configuration is functional. -->
+   It is not really used anywhere in this example, but provided the necessary dependencies this configuration is functional. -->
     <jdbc:embedded-database id="dataSource" type="H2">
         <jdbc:script location="classpath:db/schema.sql"/>
         <jdbc:script location="classpath:db/test-data.sql"/>

--- a/chapter09/transactions-xml/src/main/resources/logback.xml
+++ b/chapter09/transactions-xml/src/main/resources/logback.xml
@@ -11,7 +11,7 @@
         </encoder>
     </appender>
 
-    <logger name="com.apress.prospring5.ch8" level="debug"/>
+    <logger name="com.apress.prospring5.ch9" level="debug"/>
 
     <logger name="org.springframework.transaction" level="info"/>
 

--- a/chapter09/transactions-xml/src/main/resources/spring/tx-declarative-app-context.xml
+++ b/chapter09/transactions-xml/src/main/resources/spring/tx-declarative-app-context.xml
@@ -35,6 +35,6 @@
     </bean>
 
     <context:component-scan
-            base-package="com.apress.prospring5.ch9.services" />
+            base-package="com.apress.prospring5.ch9" />
 
 </beans>

--- a/chapter10/jsr349-assertTrue/src/main/java/com/apress/prospring5/ch10/obj/Singer.java
+++ b/chapter10/jsr349-assertTrue/src/main/java/com/apress/prospring5/ch10/obj/Singer.java
@@ -46,7 +46,7 @@ public class Singer {
 		this.gender = gender;
 	}
 
-	@AssertTrue(message="ERROR! Individual customer should have gender and last name defined")
+	@AssertTrue(message="Country Singer should have gender and last name defined")
 	public boolean isCountrySinger() {
 		boolean result = true;
 

--- a/chapter11/base-task/src/main/java/com/apress/prospring5/ch11/config/DataServiceConfig.java
+++ b/chapter11/base-task/src/main/java/com/apress/prospring5/ch11/config/DataServiceConfig.java
@@ -68,7 +68,6 @@ public class DataServiceConfig {
 		LocalContainerEntityManagerFactoryBean factoryBean = new LocalContainerEntityManagerFactoryBean();
 		factoryBean.setPackagesToScan("com.apress.prospring5.ch11.entities");
 		factoryBean.setDataSource(dataSource());
-		factoryBean.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
 		factoryBean.setJpaProperties(hibernateProperties());
 		factoryBean.setJpaVendorAdapter(jpaVendorAdapter());
 		factoryBean.afterPropertiesSet();

--- a/chapter12/base-remote/src/main/java/com/apress/prospring5/ch12/config/DataServiceConfig.java
+++ b/chapter12/base-remote/src/main/java/com/apress/prospring5/ch12/config/DataServiceConfig.java
@@ -71,7 +71,6 @@ public class DataServiceConfig {
 		LocalContainerEntityManagerFactoryBean factoryBean = new LocalContainerEntityManagerFactoryBean();
 		factoryBean.setPackagesToScan("com.apress.prospring5.ch12.entities");
 		factoryBean.setDataSource(dataSource());
-		factoryBean.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
 		factoryBean.setJpaProperties(hibernateProperties());
 		factoryBean.setJpaVendorAdapter(jpaVendorAdapter());
 		factoryBean.afterPropertiesSet();

--- a/chapter12/boot-rest/src/test/java/com/apress/prospring5/ch12/test/RestClientTest.java
+++ b/chapter12/boot-rest/src/test/java/com/apress/prospring5/ch12/test/RestClientTest.java
@@ -1,57 +1,46 @@
-package com.apress.prosring5.ch12.test;
+package com.apress.prospring5.ch12.test;
 
-import com.apress.prospring5.ch12.Singers;
 import com.apress.prospring5.ch12.entities.Singer;
-import com.apress.prosring5.ch12.RestClientConfig;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.Arrays;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Created by iuliana.cosmina on 6/17/17.
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = {RestClientConfig.class})
 public class RestClientTest {
 
 	final Logger logger = LoggerFactory.getLogger(RestClientTest.class);
-	private static final String URL_GET_ALL_SINGERS = "http://localhost:8080/rest/singer/listdata";
-	private static final String URL_GET_SINGER_BY_ID = "http://localhost:8080/rest/singer/{id}";
-	private static final String URL_CREATE_SINGER = "http://localhost:8080/rest/singer/";
-	private static final String URL_UPDATE_SINGER = "http://localhost:8080/rest/singer/{id}";
-	private static final String URL_DELETE_SINGER = "http://localhost:8080/rest/singer/{id}";
-
-	@Autowired RestTemplate restTemplate;
+	private static final String URL_GET_ALL_SINGERS = "http://localhost:8080/singer/listdata";
+	private static final String URL_GET_SINGER_BY_ID = "http://localhost:8080/singer/{id}";
+	private static final String URL_CREATE_SINGER = "http://localhost:8080/singer/";
+	private static final String URL_UPDATE_SINGER = "http://localhost:8080/singer/{id}";
+	private static final String URL_DELETE_SINGER = "http://localhost:8080/singer/{id}";
+	RestTemplate restTemplate;
 
 	@Before
 	public void setUp() {
-		assertNotNull(restTemplate);
+		restTemplate = new RestTemplate();
 	}
 
 	@Test
 	public void testFindAll() {
 		logger.info("--> Testing retrieve all singers");
-		Singers singers = restTemplate.getForObject(URL_GET_ALL_SINGERS, Singers.class);
-		assertTrue(singers.getSingers().size() == 3);
+		Singer[] singers = restTemplate.getForObject(URL_GET_ALL_SINGERS, Singer[].class);
+		assertTrue(singers.length == 3);
 		listSingers(singers);
 	}
 
 	@Test
-	public void testFindbyId() {
+	public void testFindById() {
 		logger.info("--> Testing retrieve a singer by id : 1");
 		Singer singer = restTemplate.getForObject(URL_GET_SINGER_BY_ID, Singer.class, 1);
 		assertNotNull(singer);
@@ -71,13 +60,13 @@ public class RestClientTest {
 	public void testDelete() {
 		logger.info("--> Testing delete singer by id : 3");
 		restTemplate.delete(URL_DELETE_SINGER, 3);
-		Singers singers = restTemplate.getForObject(URL_GET_ALL_SINGERS, Singers.class);
+		Singer[] singers = restTemplate.getForObject(URL_GET_ALL_SINGERS, Singer[].class);
 		Boolean found = false;
-		for(Singer s: singers.getSingers()) {
-			if(s.getId() == 3) {
+		for (Singer s : singers) {
+			if (s.getId() == 3) {
 				found = true;
 			}
-		};
+		}
 		assertFalse(found);
 		listSingers(singers);
 	}
@@ -91,16 +80,10 @@ public class RestClientTest {
 		singerNew.setBirthDate(new Date(
 				(new GregorianCalendar(1940, 8, 16)).getTime().getTime()));
 		singerNew = restTemplate.postForObject(URL_CREATE_SINGER, singerNew, Singer.class);
-
 		logger.info("Singer created successfully: " + singerNew);
-
-		Singers singers = restTemplate.getForObject(URL_GET_ALL_SINGERS, Singers.class);
-		listSingers(singers);
 	}
 
-
-
-	private void listSingers(Singers singers) {
-		singers.getSingers().forEach(s -> logger.info(s.toString()));
+	private void listSingers(Singer[] singers) {
+		Arrays.stream(singers).forEach(s -> logger.info(s.toString()));
 	}
 }

--- a/chapter12/rest/src/main/java/com/apress/prospring5/ch12/DateTimeFieldHandler.java
+++ b/chapter12/rest/src/main/java/com/apress/prospring5/ch12/DateTimeFieldHandler.java
@@ -54,7 +54,7 @@ public class DateTimeFieldHandler extends GeneralizedFieldHandler {
 			try {
 				dateTime = sdf.parse(dateTimeString);
 			} catch (ParseException e) {
-				logger.error("Not a valida date:" + dateTimeString, e);
+				logger.error("Not a valid date:" + dateTimeString, e);
 			}
 		}
 		return dateTime;

--- a/chapter12/rest/src/test/java/com/apress/prospring5/ch12/RestClientConfig.java
+++ b/chapter12/rest/src/test/java/com/apress/prospring5/ch12/RestClientConfig.java
@@ -1,18 +1,16 @@
-package com.apress.prosring5.ch12;
+package com.apress.prospring5.ch12;
 
-import org.apache.http.HttpHost;
-import org.apache.http.auth.AuthScope;
+import com.apress.prospring5.ch12.CustomCredentialsProvider;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.converter.HttpMessageConverter;
@@ -31,30 +29,17 @@ public class RestClientConfig {
 
 	@Autowired ApplicationContext ctx;
 
-	@Bean Credentials credentials(){
-		return new UsernamePasswordCredentials("prospring5", "prospring5");
-	}
-
 	@Bean
-	CredentialsProvider provider() {
-		BasicCredentialsProvider provider = new BasicCredentialsProvider();
-		provider.setCredentials(
-				AuthScope.ANY,
-				credentials());
-		return provider;
-	}
-
-	@Bean
-	public HttpComponentsClientHttpRequestFactory factory() {
-		CloseableHttpClient client = HttpClients.custom()
-				.setDefaultCredentialsProvider(provider()).build();
-		return new HttpComponentsClientHttpRequestFactory(client);
+	public HttpComponentsClientHttpRequestFactory httpRequestFactory() {
+		HttpComponentsClientHttpRequestFactory httpRequestFactory = new HttpComponentsClientHttpRequestFactory();
+		HttpClient httpClient = HttpClientBuilder.create().build();
+		httpRequestFactory.setHttpClient(httpClient);
+		return httpRequestFactory;
 	}
 
 	@Bean
 	public RestTemplate restTemplate() {
-		RestTemplate restTemplate = new RestTemplate();
-		restTemplate.setRequestFactory(factory());
+		RestTemplate restTemplate = new RestTemplate(httpRequestFactory());
 		List<HttpMessageConverter<?>> mcvs = new ArrayList<>();
 		mcvs.add(singerMessageConverter());
 		restTemplate.setMessageConverters(mcvs);
@@ -74,7 +59,7 @@ public class RestClientConfig {
 
 	@Bean CastorMarshaller castorMarshaller() {
 		CastorMarshaller castorMarshaller = new CastorMarshaller();
-		castorMarshaller.setMappingLocation(ctx.getResource("classpath:spring/oxm-mapping.xml"));
+		castorMarshaller.setMappingLocation(ctx.getResource( "classpath:spring/oxm-mapping.xml"));
 		return castorMarshaller;
 	}
 }

--- a/chapter12/rest/src/test/java/com/apress/prospring5/ch12/test/RestClientTest.java
+++ b/chapter12/rest/src/test/java/com/apress/prospring5/ch12/test/RestClientTest.java
@@ -1,8 +1,8 @@
-package com.apress.prosring5.ch12.test;
+package com.apress.prospring5.ch12.test;
 
 import com.apress.prospring5.ch12.entities.Singers;
 import com.apress.prospring5.ch12.entities.Singer;
-import com.apress.prosring5.ch12.RestClientConfig;
+import com.apress.prospring5.ch12.RestClientConfig;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,7 +50,7 @@ public class RestClientTest {
 	}
 
 	@Test
-	public void testFindbyId() {
+	public void testFindById() {
 		logger.info("--> Testing retrieve a singer by id : 1");
 		Singer singer = restTemplate.getForObject(URL_GET_SINGER_BY_ID, Singer.class, 1);
 		assertNotNull(singer);

--- a/chapter12/secure-rest/src/main/java/com/apress/prospring5/ch12/DateTimeFieldHandler.java
+++ b/chapter12/secure-rest/src/main/java/com/apress/prospring5/ch12/DateTimeFieldHandler.java
@@ -54,7 +54,7 @@ public class DateTimeFieldHandler extends GeneralizedFieldHandler {
 			try {
 				dateTime = sdf.parse(dateTimeString);
 			} catch (ParseException e) {
-				logger.error("Not a valida date:" + dateTimeString, e);
+				logger.error("Not a valid date:" + dateTimeString, e);
 			}
 		}
 		return dateTime;

--- a/chapter12/secure-rest/src/main/java/com/apress/prospring5/ch12/SingerController.java
+++ b/chapter12/secure-rest/src/main/java/com/apress/prospring5/ch12/SingerController.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 @Controller
-@RequestMapping(value="/singer")
+@RequestMapping(value="/rest/singer")
 public class SingerController {
     final Logger logger = LoggerFactory.getLogger(SingerController.class);
 

--- a/chapter12/secure-rest/src/main/java/com/apress/prospring5/ch12/init/WebInitializer.java
+++ b/chapter12/secure-rest/src/main/java/com/apress/prospring5/ch12/init/WebInitializer.java
@@ -25,7 +25,7 @@ public class WebInitializer extends AbstractAnnotationConfigDispatcherServletIni
 
     @Override
     protected String[] getServletMappings() {
-        return new String[]{"/rest/**"};
+        return new String[]{"/"};
     }
 
 }

--- a/chapter12/secure-rest/src/test/java/com/apress/prospring5/ch12/RestClientConfig.java
+++ b/chapter12/secure-rest/src/test/java/com/apress/prospring5/ch12/RestClientConfig.java
@@ -1,16 +1,18 @@
-package com.apress.prosring5.ch12;
+package com.apress.prospring5.ch12;
 
-import com.apress.prospring5.ch12.CustomCredentialsProvider;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
-import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.converter.HttpMessageConverter;
@@ -29,17 +31,30 @@ public class RestClientConfig {
 
 	@Autowired ApplicationContext ctx;
 
+	@Bean Credentials credentials(){
+		return new UsernamePasswordCredentials("prospring5", "prospring5");
+	}
+
 	@Bean
-	public HttpComponentsClientHttpRequestFactory httpRequestFactory() {
-		HttpComponentsClientHttpRequestFactory httpRequestFactory = new HttpComponentsClientHttpRequestFactory();
-		HttpClient httpClient = HttpClientBuilder.create().build();
-		httpRequestFactory.setHttpClient(httpClient);
-		return httpRequestFactory;
+	CredentialsProvider provider() {
+		BasicCredentialsProvider provider = new BasicCredentialsProvider();
+		provider.setCredentials(
+				AuthScope.ANY,
+				credentials());
+		return provider;
+	}
+
+	@Bean
+	public HttpComponentsClientHttpRequestFactory factory() {
+		CloseableHttpClient client = HttpClients.custom()
+				.setDefaultCredentialsProvider(provider()).build();
+		return new HttpComponentsClientHttpRequestFactory(client);
 	}
 
 	@Bean
 	public RestTemplate restTemplate() {
-		RestTemplate restTemplate = new RestTemplate(httpRequestFactory());
+		RestTemplate restTemplate = new RestTemplate();
+		restTemplate.setRequestFactory(factory());
 		List<HttpMessageConverter<?>> mcvs = new ArrayList<>();
 		mcvs.add(singerMessageConverter());
 		restTemplate.setMessageConverters(mcvs);
@@ -59,7 +74,7 @@ public class RestClientConfig {
 
 	@Bean CastorMarshaller castorMarshaller() {
 		CastorMarshaller castorMarshaller = new CastorMarshaller();
-		castorMarshaller.setMappingLocation(ctx.getResource( "classpath:spring/oxm-mapping.xml"));
+		castorMarshaller.setMappingLocation(ctx.getResource("classpath:spring/oxm-mapping.xml"));
 		return castorMarshaller;
 	}
 }

--- a/chapter12/secure-rest/src/test/java/com/apress/prospring5/ch12/test/RestClientTest.java
+++ b/chapter12/secure-rest/src/test/java/com/apress/prospring5/ch12/test/RestClientTest.java
@@ -1,46 +1,57 @@
-package com.apress.prosring5.ch12.test;
+package com.apress.prospring5.ch12.test;
 
+import com.apress.prospring5.ch12.Singers;
 import com.apress.prospring5.ch12.entities.Singer;
+import com.apress.prospring5.ch12.RestClientConfig;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.Arrays;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by iuliana.cosmina on 6/17/17.
  */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {RestClientConfig.class})
 public class RestClientTest {
 
 	final Logger logger = LoggerFactory.getLogger(RestClientTest.class);
-	private static final String URL_GET_ALL_SINGERS = "http://localhost:8080/singer/listdata";
-	private static final String URL_GET_SINGER_BY_ID = "http://localhost:8080/singer/{id}";
-	private static final String URL_CREATE_SINGER = "http://localhost:8080/singer/";
-	private static final String URL_UPDATE_SINGER = "http://localhost:8080/singer/{id}";
-	private static final String URL_DELETE_SINGER = "http://localhost:8080/singer/{id}";
-	RestTemplate restTemplate;
+	private static final String URL_GET_ALL_SINGERS = "http://localhost:8080/rest/singer/listdata";
+	private static final String URL_GET_SINGER_BY_ID = "http://localhost:8080/rest/singer/{id}";
+	private static final String URL_CREATE_SINGER = "http://localhost:8080/rest/singer/";
+	private static final String URL_UPDATE_SINGER = "http://localhost:8080/rest/singer/{id}";
+	private static final String URL_DELETE_SINGER = "http://localhost:8080/rest/singer/{id}";
+
+	@Autowired RestTemplate restTemplate;
 
 	@Before
 	public void setUp() {
-		restTemplate = new RestTemplate();
+		assertNotNull(restTemplate);
 	}
 
 	@Test
 	public void testFindAll() {
 		logger.info("--> Testing retrieve all singers");
-		Singer[] singers = restTemplate.getForObject(URL_GET_ALL_SINGERS, Singer[].class);
-		assertTrue(singers.length == 3);
+		Singers singers = restTemplate.getForObject(URL_GET_ALL_SINGERS, Singers.class);
+		assertTrue(singers.getSingers().size() == 3);
 		listSingers(singers);
 	}
 
 	@Test
-	public void testFindbyId() {
+	public void testFindById() {
 		logger.info("--> Testing retrieve a singer by id : 1");
 		Singer singer = restTemplate.getForObject(URL_GET_SINGER_BY_ID, Singer.class, 1);
 		assertNotNull(singer);
@@ -60,13 +71,13 @@ public class RestClientTest {
 	public void testDelete() {
 		logger.info("--> Testing delete singer by id : 3");
 		restTemplate.delete(URL_DELETE_SINGER, 3);
-		Singer[] singers = restTemplate.getForObject(URL_GET_ALL_SINGERS, Singer[].class);
+		Singers singers = restTemplate.getForObject(URL_GET_ALL_SINGERS, Singers.class);
 		Boolean found = false;
-		for (Singer s : singers) {
-			if (s.getId() == 3) {
+		for(Singer s: singers.getSingers()) {
+			if(s.getId() == 3) {
 				found = true;
 			}
-		}
+		};
 		assertFalse(found);
 		listSingers(singers);
 	}
@@ -80,10 +91,16 @@ public class RestClientTest {
 		singerNew.setBirthDate(new Date(
 				(new GregorianCalendar(1940, 8, 16)).getTime().getTime()));
 		singerNew = restTemplate.postForObject(URL_CREATE_SINGER, singerNew, Singer.class);
+
 		logger.info("Singer created successfully: " + singerNew);
+
+		Singers singers = restTemplate.getForObject(URL_GET_ALL_SINGERS, Singers.class);
+		listSingers(singers);
 	}
 
-	private void listSingers(Singer[] singers) {
-		Arrays.stream(singers).forEach(s -> logger.info(s.toString()));
+
+
+	private void listSingers(Singers singers) {
+		singers.getSingers().forEach(s -> logger.info(s.toString()));
 	}
 }

--- a/chapter13/base-test/src/main/java/com/apress/prospring5/ch13/config/ServiceConfig.java
+++ b/chapter13/base-test/src/main/java/com/apress/prospring5/ch13/config/ServiceConfig.java
@@ -53,7 +53,6 @@ public class ServiceConfig {
 		LocalContainerEntityManagerFactoryBean factoryBean = new LocalContainerEntityManagerFactoryBean();
 		factoryBean.setPackagesToScan("com.apress.prospring5.ch13.entities");
 		factoryBean.setDataSource(dataSource);
-		factoryBean.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
 		factoryBean.setJpaProperties(hibernateProperties());
 		factoryBean.setJpaVendorAdapter(jpaVendorAdapter());
 		factoryBean.afterPropertiesSet();

--- a/chapter13/base-test/src/main/resources/logback.xml
+++ b/chapter13/base-test/src/main/resources/logback.xml
@@ -11,7 +11,7 @@
         </encoder>
     </appender>
 
-    <logger name="com.apress.prospring5.ch12" level="debug"/>
+    <logger name="com.apress.prospring5.ch13" level="debug"/>
 
     <logger name="org.springframework" level="off"/>
 

--- a/chapter13/integration-test/src/test/java/com/apress/prospring5/ch13/SingerServiceImplTest.java
+++ b/chapter13/integration-test/src/test/java/com/apress/prospring5/ch13/SingerServiceImplTest.java
@@ -73,7 +73,7 @@ public class SingerServiceImplTest extends AbstractTransactionalJUnit4SpringCont
         assertEquals(1, singers.size());
     }
 
-    @Test(expected=ConstraintViolationException.class)
+    @Test(expected=AssertionError.class)
     public void testAddSingerWithJSR349Error() throws Exception {
         deleteFromTables("SINGER");
 

--- a/chapter13/junit5-test/build.gradle
+++ b/chapter13/junit5-test/build.gradle
@@ -2,6 +2,9 @@ dependencies {
     compile project(':chapter13:base-test')
     testCompile testing.junit5Engine, testing.mockito, spring.test
 }
+test {
+	useJUnitPlatform()
+}
 
 jar {
     manifest {

--- a/chapter13/junit5-test/src/test/java/com/apress/prospring5/ch13/SingerServiceTest.java
+++ b/chapter13/junit5-test/src/test/java/com/apress/prospring5/ch13/SingerServiceTest.java
@@ -49,7 +49,7 @@ public class SingerServiceTest {
 
 	@AfterEach
 	void dispose() {
-		logger.info("--> @AfterEach - executes before each test method in this class");
+		logger.info("--> @AfterEach - executes after each test method in this class");
 	}
 
 	@Test

--- a/chapter13/mvc-unit-test/src/test/java/com/apress/prospring5/ch13/jmock/SingerControllerTest.java
+++ b/chapter13/mvc-unit-test/src/test/java/com/apress/prospring5/ch13/jmock/SingerControllerTest.java
@@ -1,4 +1,4 @@
-package om.apress.prospring5.ch13.jmock;
+package com.apress.prospring5.ch13.jmock;
 
 import com.apress.prospring5.ch13.SingerController;
 import com.apress.prospring5.ch13.entities.Singer;

--- a/chapter14/base-groovy/src/main/groovy/com/apress/prospring5/ch14/Runner.groovy
+++ b/chapter14/base-groovy/src/main/groovy/com/apress/prospring5/ch14/Runner.groovy
@@ -14,7 +14,7 @@ println anotherSinger
 println singer.firstName + 39
 println anotherSinger.firstName + 39
 
-//Siplified Syntax
+//Simplified Syntax
 def list = ['This', 'is', 'John Mayer']
 println list
 

--- a/chapter15/boot-jmx/build.gradle
+++ b/chapter15/boot-jmx/build.gradle
@@ -24,7 +24,7 @@ jar {
     manifest {
         attributes("Created-By": "Iuliana Cosmina",
                 "Specification-Title": "Pro Spring 5",
-                "Main-Class"         : "com.apress.prospring5.ch15.Application",
+                "Main-Class"         : "com.apress.prospring5.ch15.JMXBootApplication",
                 "Class-Path": configurations.compile.collect { it.getName() }.join(' '))
     }
 }

--- a/chapter15/jmx/src/main/java/com/apress/prospring5/ch15/DateTimeFieldHandler.java
+++ b/chapter15/jmx/src/main/java/com/apress/prospring5/ch15/DateTimeFieldHandler.java
@@ -54,7 +54,7 @@ public class DateTimeFieldHandler extends GeneralizedFieldHandler {
             try {
                 dateTime = sdf.parse(dateTimeString);
             } catch (ParseException e) {
-                logger.error("Not a valida date:" + dateTimeString, e);
+                logger.error("Not a valid date:" + dateTimeString, e);
             }
         }
         return dateTime;

--- a/chapter15/jmx/src/main/java/com/apress/prospring5/ch15/init/WebConfig.java
+++ b/chapter15/jmx/src/main/java/com/apress/prospring5/ch15/init/WebConfig.java
@@ -111,7 +111,7 @@ public class WebConfig implements WebMvcConfigurer {
 		MBeanExporter exporter = new MBeanExporter();
 		Map<String, Object> beans = new HashMap<>();
 		beans.put("bean:name=ProSpring5SingerApp", appStatisticsBean());
-		beans.put("bean:name=Prospring5SingerApp-hibernate", statisticsBean());
+		beans.put("bean:name=ProSpring5SingerApp-hibernate", statisticsBean());
 		exporter.setBeans(beans);
 		return exporter;
 	}

--- a/chapter16/singer-webapp-boot/src/test/java/com/apress/prospring5/ch16/repos/SingerRepoTest.java
+++ b/chapter16/singer-webapp-boot/src/test/java/com/apress/prospring5/ch16/repos/SingerRepoTest.java
@@ -1,11 +1,12 @@
-package com.apress.prospring5.ch16.web.com.apress.prospring5.ch16.repo;
+package com.apress.prospring5.ch16.repos;
 
 import com.apress.prospring5.ch16.entities.Singer;
-import com.apress.prospring5.ch16.repos.SingerRepository;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.Date;
@@ -18,6 +19,7 @@ import static org.junit.Assert.assertEquals;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest
+@DirtiesContext(classMode=ClassMode.AFTER_CLASS)
 public class SingerRepoTest {
 
 	private SingerRepository singerRepository;
@@ -36,7 +38,7 @@ public class SingerRepoTest {
 				(new GregorianCalendar(1991, 2, 17)).getTime().getTime()));
 		singerRepository.save(singer);
 
-		//get all aingers, list should only have one
+		//get all singers, list should have 15
 		Iterable<Singer> singers = singerRepository.findAll();
 		int count = 0;
 

--- a/chapter16/singer-webapp-boot/src/test/java/com/apress/prospring5/ch16/web/HelloControllerTest.java
+++ b/chapter16/singer-webapp-boot/src/test/java/com/apress/prospring5/ch16/web/HelloControllerTest.java
@@ -6,6 +6,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -21,6 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DirtiesContext(classMode=ClassMode.AFTER_CLASS)
 public class HelloControllerTest {
 
 

--- a/chapter16/singer-webapp-jcfg/src/main/java/com/apress/prospring5/ch16/config/DataServiceConfig.java
+++ b/chapter16/singer-webapp-jcfg/src/main/java/com/apress/prospring5/ch16/config/DataServiceConfig.java
@@ -67,7 +67,6 @@ public class DataServiceConfig {
 		LocalContainerEntityManagerFactoryBean factoryBean = new LocalContainerEntityManagerFactoryBean();
 		factoryBean.setPackagesToScan("com.apress.prospring5.ch16.entities");
 		factoryBean.setDataSource(dataSource());
-		factoryBean.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
 		factoryBean.setJpaProperties(hibernateProperties());
 		factoryBean.setJpaVendorAdapter(jpaVendorAdapter());
 		factoryBean.afterPropertiesSet();

--- a/chapter16/singer-webapp-jcfg/src/main/java/com/apress/prospring5/ch16/config/WebConfig.java
+++ b/chapter16/singer-webapp-jcfg/src/main/java/com/apress/prospring5/ch16/config/WebConfig.java
@@ -30,7 +30,7 @@ import java.util.Locale;
 @ComponentScan(basePackages = {"com.apress.prospring5.ch16"})
 public class WebConfig implements WebMvcConfigurer {
 
-	//Declare our static resources. I added cache to the java config but it?s not required.
+	//Declare our static resources. I added cache to the java config but it's not required.
 	@Override
 	public void addResourceHandlers(ResourceHandlerRegistry registry) {
 		registry.addResourceHandler("/resources/**").addResourceLocations("/")
@@ -72,7 +72,7 @@ public class WebConfig implements WebMvcConfigurer {
 		return validator();
 	}
 
-	// <=> replacement for 'typeConversionService'  ban
+	// <=> replacement for 'typeConversionService'  bean
 	@Override
 	public void addFormatters(FormatterRegistry formatterRegistry) {
 		formatterRegistry.addFormatter(dateFormatter());
@@ -101,7 +101,9 @@ public class WebConfig implements WebMvcConfigurer {
 
 	@Bean
 	LocaleChangeInterceptor localeChangeInterceptor() {
-		return new LocaleChangeInterceptor();
+		LocaleChangeInterceptor interceptor = new LocaleChangeInterceptor();
+		interceptor.setParamName("lang");
+		return interceptor;
 	}
 
 	@Bean ResourceBundleThemeSource themeSource() {

--- a/chapter16/singer-webapp-jcfg/src/main/java/com/apress/prospring5/ch16/web/SingerController.java
+++ b/chapter16/singer-webapp-jcfg/src/main/java/com/apress/prospring5/ch16/web/SingerController.java
@@ -114,7 +114,6 @@ public class SingerController {
                 InputStream inputStream = file.getInputStream();
                 if (inputStream == null) logger.info("File inputstream is null");
                 fileContent = IOUtils.toByteArray(inputStream);
-                singer.setPhoto(fileContent);
             } catch (IOException ex) {
                 logger.error("Error saving uploaded file");
             }

--- a/chapter16/singer-webapp-jcfg/src/main/webapp/WEB-INF/views/singers/list.jspx
+++ b/chapter16/singer-webapp-jcfg/src/main/webapp/WEB-INF/views/singers/list.jspx
@@ -10,7 +10,7 @@
     <spring:message code="label_singer_first_name" var="labelSingerFirstName"/>
     <spring:message code="label_singer_last_name" var="labelSingerLastName"/>
     <spring:message code="label_singer_birth_date" var="labelSingerBirthDate"/>
-    <spring:url value="/singers/" var="showSingerUrl"/>
+    <spring:url value="/singers" var="showSingerUrl"/>
 
     <script type="text/javascript">
         $(function(){

--- a/chapter16/singer-webapp-jcfg/src/main/webapp/styles/standard.css
+++ b/chapter16/singer-webapp-jcfg/src/main/webapp/styles/standard.css
@@ -1,5 +1,9 @@
 @import url("messages/messages.css");
 
+.banner {
+    background: url("../images/banner.png") no-repeat 0px center;
+    height: 90px;
+}
 /* main elements */
 
 body,div,td {

--- a/chapter16/singer-webapp-xml/src/main/java/com/apress/prospring5/ch16/web/SingerController.java
+++ b/chapter16/singer-webapp-xml/src/main/java/com/apress/prospring5/ch16/web/SingerController.java
@@ -113,7 +113,6 @@ public class SingerController {
                 InputStream inputStream = file.getInputStream();
                 if (inputStream == null) logger.info("File inputstream is null");
                 fileContent = IOUtils.toByteArray(inputStream);
-                singer.setPhoto(fileContent);
             } catch (IOException ex) {
                 logger.error("Error saving uploaded file");
             }

--- a/chapter16/singer-webapp-xml/src/main/webapp/WEB-INF/views/singers/list.jspx
+++ b/chapter16/singer-webapp-xml/src/main/webapp/WEB-INF/views/singers/list.jspx
@@ -10,7 +10,7 @@
     <spring:message code="label_singer_first_name" var="labelSingerFirstName"/>
     <spring:message code="label_singer_last_name" var="labelSingerLastName"/>
     <spring:message code="label_singer_birth_date" var="labelSingerBirthDate"/>
-    <spring:url value="/singers/" var="showSingerUrl"/>
+    <spring:url value="/singers" var="showSingerUrl"/>
 
     <script type="text/javascript">
         $(function(){

--- a/chapter17/sockjs-cfg/src/main/webapp/static/index.html
+++ b/chapter17/sockjs-cfg/src/main/webapp/static/index.html
@@ -77,7 +77,7 @@
 <body>
 <h2>SockJS Tester</h2>
     Target:
-    <input id="target" size="40" value="http://localhost:8080/sockjs/echoHandler"/>
+    <input id="target" size="40" value="http://localhost:8080/echoHandler"/>
     <br/>
     <button id="connect">Connect</button>
     <button id="disconnect">Disconnect</button>

--- a/chapter17/sockjs/src/main/webapp/static/index.html
+++ b/chapter17/sockjs/src/main/webapp/static/index.html
@@ -77,7 +77,7 @@
 <body>
 <h2>SockJS Tester</h2>
     Target:
-    <input id="target" size="40" value="http://localhost:8080/sockjs/echoHandler"/>
+    <input id="target" size="40" value="http://localhost:8080/echoHandler"/>
     <br/>
     <button id="connect">Connect</button>
     <button id="disconnect">Disconnect</button>

--- a/chapter17/stomp-cfg/src/main/webapp/static/index.html
+++ b/chapter17/stomp-cfg/src/main/webapp/static/index.html
@@ -5,7 +5,7 @@
     <script src="http://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.2/stomp.min.js"></script>
     <script src="http://code.jquery.com/jquery-2.1.1.min.js"></script>
     <script>
-        var stomp = Stomp.over(new SockJS("/stomp/ws"));
+        var stomp = Stomp.over(new SockJS("/ws"));
 
         function displayStockPrice(frame) {
             var prices = JSON.parse(frame.body);

--- a/chapter17/stomp/src/main/webapp/static/index.html
+++ b/chapter17/stomp/src/main/webapp/static/index.html
@@ -5,7 +5,7 @@
     <script src="http://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.2/stomp.min.js"></script>
     <script src="http://code.jquery.com/jquery-2.1.1.min.js"></script>
     <script>
-        var stomp = Stomp.over(new SockJS("/stomp/ws"));
+        var stomp = Stomp.over(new SockJS("/ws"));
 
         function displayStockPrice(frame) {
             var prices = JSON.parse(frame.body);

--- a/chapter17/websocket-api-cfg/src/main/webapp/static/index.html
+++ b/chapter17/websocket-api-cfg/src/main/webapp/static/index.html
@@ -76,7 +76,7 @@
 <body>
     <h2>WebSocket Tester</h2>
     Target:
-    <input id="target" size="40" value="ws://localhost:8080/websocket-api/echoHandler"/>
+    <input id="target" size="40" value="ws://localhost:8080/echoHandler"/>
     <br/>
     <button id="connect">Connect</button>
     <button id="disconnect">Disconnect</button>

--- a/chapter17/websocket-api/src/main/webapp/static/index.html
+++ b/chapter17/websocket-api/src/main/webapp/static/index.html
@@ -76,7 +76,7 @@
 <body>
 <h2>WebSocket Tester</h2>
 Target:
-<input type="text" id="target" size="40" value="ws://localhost:8080/websocket-api/echoHandler"/>
+<input type="text" id="target" size="40" value="ws://localhost:8080/echoHandler"/>
 <br/>
 <button id="connect">Connect</button>
 <button id="disconnect">Disconnect</button>

--- a/chapter18/batch-jsr352/build.gradle
+++ b/chapter18/batch-jsr352/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	compile db.hsqldb,db.dbcp
+	compile db.hsqldb,db.dbcp, db.dbcp2
 }
 
 jar {

--- a/chapter18/boot-tests/src/test/java/com/apress/prospring5/ch18/test/IntegrationTwoTest.java
+++ b/chapter18/boot-tests/src/test/java/com/apress/prospring5/ch18/test/IntegrationTwoTest.java
@@ -20,12 +20,12 @@ public class IntegrationTwoTest {
 	@Autowired FluxGenerator fluxGenerator;
 
 	@Test
-	public void test1One() {
+	public void test1Two() {
 		fluxGenerator.generate("a", "b", "c").collectList().block().forEach(logger::info);
 	}
 
 	@Test
-	public void test2One() {
+	public void test2Two() {
 		fluxGenerator.generate( "aa", "bb", "cc").collectList().block().forEach(logger::info);
 	}
 }

--- a/chapter18/chapter18.gradle
+++ b/chapter18/chapter18.gradle
@@ -10,13 +10,13 @@ subprojects {
 
 	dependencies {
 		if (!project.name.contains("boot") && !project.name.contains("webflux")) {
-			compile(spring.jdbc) {
-				//exclude these as batchCore will bring them on as transitive dependencies
+			compile(spring.batchCore) {
+				//exclude these as jdbc will bring them on as transitive dependencies
 				exclude module: 'spring-core'
 				exclude module: 'spring-beans'
 				exclude module: 'spring-tx'
 			}
-			compile spring.batchCore, misc.io, misc.slf4jJcl, misc.logback, misc.lang3
+			compile spring.jdbc, misc.io, misc.slf4jJcl, misc.logback, misc.lang3
 		}
 	}
 }

--- a/chapter18/webflux/build.gradle
+++ b/chapter18/webflux/build.gradle
@@ -13,7 +13,7 @@ dependencies {
             react.reactiveStreams, react.projReactIpc, react.tomcatEmbedded*/
 
 war {
-    archiveName = 'singer-webapp-jcfg.war'
+    archiveName = 'webflux.war'
     manifest {
         attributes("Created-By"      : "Iuliana Cosmina",
                 "Specification-Title": "Pro Spring 5",

--- a/chapter18/webflux/src/main/java/com/apress/prospring5/ch18/DataServiceConfig.java
+++ b/chapter18/webflux/src/main/java/com/apress/prospring5/ch18/DataServiceConfig.java
@@ -67,7 +67,6 @@ public class DataServiceConfig {
 		LocalContainerEntityManagerFactoryBean factoryBean = new LocalContainerEntityManagerFactoryBean();
 		factoryBean.setPackagesToScan("com.apress.prospring5.ch18.entities");
 		factoryBean.setDataSource(dataSource());
-		factoryBean.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
 		factoryBean.setJpaProperties(hibernateProperties());
 		factoryBean.setJpaVendorAdapter(jpaVendorAdapter());
 		factoryBean.afterPropertiesSet();

--- a/chapter18/webflux/src/test/java/com/apress/prospring5/ch18/web/SingerHandlerTest.java
+++ b/chapter18/webflux/src/test/java/com/apress/prospring5/ch18/web/SingerHandlerTest.java
@@ -31,7 +31,7 @@ public class SingerHandlerTest {
 	WebTestClient testClient;
 
 	@Test
-	public void getPerson() throws Exception {
+	public void getSinger() throws Exception {
 		List<Singer> result = this.testClient.get()
 				.uri("/1")
 				.exchange()

--- a/chapter18/xd/src/main/java/com/apress/prospring5/ch18/SingerJobResults.java
+++ b/chapter18/xd/src/main/java/com/apress/prospring5/ch18/SingerJobResults.java
@@ -1,4 +1,4 @@
-package com.apress.prospring4.ch18;
+package com.apress.prospring5.ch18;
 
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.slf4j.Logger;

--- a/chapter18/xd/src/main/resources/README.adoc
+++ b/chapter18/xd/src/main/resources/README.adoc
@@ -7,7 +7,7 @@
 .Then go ahead on your business
 * create the database schema in MySql by running the commands from resources/support/ddl.sql in your MySQL WorkBench with root
 * open a shell and go to spring-xd-1.3.2.RELEASE/xd/bin/ and run *./xd-singlenode* to start the Spring XD engine
-* open another shell and go to spring-xd-1.3.2.RELEASE/shell/bin/  and tun *./xd-shell* to start the Spring XD shell
+* open another shell and go to spring-xd-1.3.2.RELEASE/shell/bin/  and run *./xd-shell* to start the Spring XD shell
 * in the XD shell paste the following line (after correcting the location of the singers.csv file of course)
 [source,ruby]
 ----


### PR DESCRIPTION
Hi,

Having spent some time poring over the book, I though it would be useful to submit some corrections that I found in the code base.

This PR, although looks big, is merely an errata, correcting various typos and inconsistencies. There are very few actual changes, and I’ll explain each of them below. Other than that, I found the book very useful, and, moreover, I liked the fact that every example worked as stated. There are not many software books that can make such a claim.



**build.gradle:**
* I changed artemisVersion to 2.4.0 to eliminate a “NoClassDefFoundError” in boot-jms and jms-artemis project.
* I changed web.servlet from javax.servlet:javax.servlet-api:3.1.0 to javax:javaee-web-api:7.0 to eliminate an error flagged by my IDE (Eclipse Photon) in singer-webapp-jcfg|xml/default.jspx. The error was “JspException cannot be resolved. Apparently “servlet-api” is only a subset of “javaee-web-api”.

**bean-inheritance/build.gradle:**
* I changed the name of the Main-Class to the one actually in the project, so that the command “java -jar jarful” would work. The are other places with the same correction, and I will not comment on them anymore.

**method-replacement/FormatMessageReplacer.java:**
The method “reimplement” overrides a base class method where one argument is Object[]. For some reason, my IDE complains when we pass Object… in the overridden method. I just wanted to get rid of the warning.

**plain-jdbc/Singer.java**
* I changed the name of “addAbum” to “addAlbum”, obviously a typo. This typo is repeated in other “Singer” files, that have been similarly corrected, along with all the references from other files. I will not comment on them anymore.

**spring-jdbc-annotations/JdbcSingerDao.java:**
* Obvious correction from “update” to “delete”

**hibernate-envers/EnversConfig.java:**
* Here the line “factoryBean.setJpaVendorAdapter(new HibernateJpaVendorAdapter());” is superseded two lines below. I eliminated it. There are other similar places, and I will not comment on them anymore.

**base-dao/XAJpaConfig.java:**
* I changed user/password to be consistent with the definitions in other places.

**secure-rest/SingerController.java:**
* I changed the mapping to make it consistent with other places in the project, and to make it work.

**junit5-test/build.gradle:**
* I had to add “useJunitPlatform” after researching online to make this work. I’m not sure why this is needed.

**singer-webapp-boot/HelloControllerTest.java**
* This annotation forces the context to be reloaded on each test, allowing the tests to succeed when running “gradle clean build” from the command line.

**singer-webapp-jcfg/WebConfig.java:**
* The change is needed to make switching from English to Chinese work. The “lang” param name is actually set in the twin “xml” project. When the param is not set, the default is “locale”, not “lang”.

**singer-webapp-jcfg/SingerController.java:**
* Redundant line.

**singer-webapp-jcfg/list.jspx**
* This is a subtle issue I experienced. The second slash in “/singers/“ is not only redundant, resulting in a double-slash in the URL, but makes Tomcat (I used Tomcat 9.0.14) to complain about a not well formed URL and refusing to render the expected functionality. After researching online I discovered the cause is the double-slash. Not sure why is this.

**singer-webapp-jcfg/standard.css:**
* I just wanted “banner.pgn” on the pages like the twin “xml” project does.

**sockjs-cfg/index.html:**
* Eliminated “socks” from the URL to be consistent with the mapping in the code.

**batch-jsr352/build.gradle:**
* The project needed the extra dependency.

**chapter18/chapter18.gradle:**
I had to swap “spring.jdbc” and “spring.BatchCore”. “spring.jdbc” brings in 5.0.10.RELEASE dependencies, while “spring.BatchCore” brings in older spring dependencies, and they don’t work with the rest. The swap eliminates the “core|beans|tx” versions that “batchCore” brings in and lets “jdbc” to come with correct 5.0.10 versions.

* Finally, in some projects in chapter12 and 13 some package names were wrong. For example, there is a typo of “prosring5” instead of “prospring5” I renamed the packages accordingly.


Best Regards,
Adrian Dumascu
adumascu@yahoo.com

