### PR TITLE
Update jdbc.properties

### DIFF
--- a/chapter06/spring-jdbc-embedded/src/main/resources/db/jdbc.properties
+++ b/chapter06/spring-jdbc-embedded/src/main/resources/db/jdbc.properties
@@ -1,6 +1,6 @@
 # For running application with H2 in memory database
 driverClassName=org.h2.Driver
-url=jdbc:h2:~/musicdb
-username=prospring5
-password=prospring5
+url=jdbc:h2:~/test
+username=
+password=
 


### PR DESCRIPTION
The original values don't work. The default url for h2 embeded should be
jdbc:h2:~/test ('test' in the user home directory). And both username
and password should be empty.